### PR TITLE
Allowed multirun

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,7 @@
     "no-console": "off",
     "no-restricted-syntax": "off",
     "max-classes-per-file": "off",
+    "class-methods-use-this": "off",
     "import/prefer-default-export": "off",
     "prefer-destructuring": ["error", { "array": false }],
     "import/first": "off",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "lint": "./node_modules/.bin/eslint --ext js,ts src",
     "build": "tsc",
     "gcp-build": "npm run build",
-    "start": "echo Select a platform to start by running \"npm run [platform]\"",
-    "telegram": "node lib/telegram/bot_telegram.js",
-    "discord": "node lib/discord/bot_discord.js",
+    "start": "node lib/app.js --telegram --discord",
+    "telegram": "node lib/app.js --telegram",
+    "discord": "node lib/app.js --discord",
     "test": "mocha -r ts-node/register tests/**/*.test.ts"
   },
   "dependencies": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,7 +3,10 @@ import * as core from "./core/core"
 import * as telegram from "./telegram/bot_telegram"
 
 import * as discord from "./discord/bot_discord"
+import { TelegramConfig } from "./telegram/types_telegram"
 
 console.log("Starting bot fleet...")
+
+const telegramBot = new telegram.EnforcingTelegramBot(new TelegramConfig())
 
 // This doesn't work like that, i'm nub

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,12 +1,9 @@
-import * as core from "./core/core"
-
 import * as telegram from "./telegram/bot_telegram"
-
 import * as discord from "./discord/bot_discord"
 import { TelegramConfig } from "./telegram/types_telegram"
+import { DiscordConfig } from "./discord/types_discord"
 
 console.log("Starting bot fleet...")
 
 const telegramBot = new telegram.EnforcingTelegramBot(new TelegramConfig())
-
-// This doesn't work like that, i'm nub
+const discordBot = new discord.EnforcingDiscordBot(new DiscordConfig())

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,7 +3,21 @@ import * as discord from "./discord/bot_discord"
 import { TelegramConfig } from "./telegram/types_telegram"
 import { DiscordConfig } from "./discord/types_discord"
 
-console.log("Starting bot fleet...")
+let telegramRunning = false
+let discordRunning = false
 
-const telegramBot = new telegram.EnforcingTelegramBot(new TelegramConfig())
-const discordBot = new discord.EnforcingDiscordBot(new DiscordConfig())
+if (process.argv.includes("--telegram")) {
+  const telegramBot = new telegram.EnforcingTelegramBot(new TelegramConfig())
+  telegramRunning = true
+  console.log("Started Telegram bot.")
+}
+
+if (process.argv.includes("--discord")) {
+  const discordBot = new discord.EnforcingDiscordBot(new DiscordConfig())
+  discordRunning = true
+  console.log("Started Discord bot.")
+}
+
+if (!telegramRunning && !discordRunning) {
+  console.error("You must run bot for at least one platform!")
+}

--- a/src/discord/bot_discord.ts
+++ b/src/discord/bot_discord.ts
@@ -12,7 +12,7 @@ const { config } = core
 export class EnforcingDiscordBot extends DiscordBot.Client {
   constructor(discordConfig: DiscordConfig) {
     super()
-    this.login(discordConfig.TOKEN)
+    this.login(discordConfig.DISCORD_TOKEN)
 
     // Handles all messages and checks whether they're in the specified language
     this.on("message", async msg => {

--- a/src/discord/bot_discord.ts
+++ b/src/discord/bot_discord.ts
@@ -8,179 +8,112 @@ import * as core from "../core/core"
 import { DiscordConfig } from "./types_discord"
 
 const { config } = core
-const discordConfig = new DiscordConfig()
 
-export const bot = new DiscordBot.Client()
-bot.login(discordConfig.TOKEN)
+export class EnforcingDiscordBot extends DiscordBot.Client {
+  constructor(discordConfig: DiscordConfig) {
+    super()
+    this.login(discordConfig.TOKEN)
 
-/**
- * Returns true if the user is an admin or a creator, false otherwise.
- */
-function isAdminUser(guildMember: DiscordBot.GuildMember): boolean {
-  return guildMember.hasPermission("MANAGE_MESSAGES") // users who manage messages can't be muted
-}
+    // Handles all messages and checks whether they're in the specified language
+    this.on("message", async msg => {
+      if (msg.author === this.user) {
+        // prevents reacting to own messages
+        return
+      }
 
-/**
- * Handles adding words to the exception list
- */
-async function handleExcept(msg: DiscordBot.Message, match): Promise<void> {
-  if (!msg.member || !isAdminUser(msg.member)) {
-    console.log("User is not an admin or has left the server. Returned.")
-    msg.reply("Sorry, this is a admin-only feature.")
-    return
+      if (msg.content === undefined) {
+        console.log("Message doesn't contain text, returned. (msg.content === undefined)")
+        return
+      }
+
+      if (msg.channel instanceof DiscordBot.DMChannel) {
+        console.log(
+          "Message was sent in a private chat, returned. (msg.channel instanceof DiscordBot.DMChannel)"
+        )
+        msg.reply("Sorry, I work only in servers.")
+        return
+      }
+
+      const exceptMatch = msg.content.match(/\/except (.+)/)
+      const removeMatch = msg.content.match(/\/remove (.+)/)
+
+      if (exceptMatch) {
+        this.handleExcept(msg, exceptMatch)
+      } else if (removeMatch) {
+        this.handleRemove(msg, removeMatch)
+      }
+
+      const translationContext = await core.translateAndCheck(msg.content)
+
+      if (!translationContext) {
+        console.log("translationContext is null. That's probably an error. Returned.")
+        return
+      }
+
+      if (!translationContext.isCorrectLang) {
+        const permitted = await core.shouldBePermitted(msg.content)
+
+        if (!permitted && translationContext.translation) {
+          this.performAction(
+            msg,
+            translationContext.translation.detectedLangName,
+            translationContext.requiredLangName,
+            translationContext.translation.translatedText
+          )
+        }
+      }
+    })
   }
 
-  const inputText = match[1]
-
-  const successful = await core.addException(inputText)
-
-  if (successful) {
-    msg.reply(`Okay, "${inputText}" has been added to the exception list. `)
-  } else {
-    msg.reply(`An error occurred while adding the word ${inputText}`)
-  }
-}
-
-/**
- * Handles removing words from the exception list
- */
-async function handleRemove(msg: DiscordBot.Message, match): Promise<void> {
-  if (!msg.member || !isAdminUser(msg.member)) {
-    console.log("User is not an admin or has left the server. Returned.")
-    msg.reply("Sorry, this is a admin-only feature.")
-    return
+  /**
+   * Returns true if the user is an admin or a creator, false otherwise.
+   */
+  static isAdminUser(guildMember: DiscordBot.GuildMember): boolean {
+    return guildMember.hasPermission("MANAGE_MESSAGES") // users who manage messages can't be muted
   }
 
-  const inputText = match[1]
-
-  const successful = await core.removeException(inputText)
-
-  if (successful) {
-    msg.reply(`Okay, "${inputText}" has been removed from the exception list. `)
-  } else {
-    msg.reply(`An error occurred while removing the word ${inputText}`)
-  }
-}
-
-// Handles all messages and checks whether they're in the specified language
-bot.on("message", async msg => {
-  if (msg.author === bot.user) {
-    // prevents reacting to own messages
-    return
-  }
-
-  if (msg.content === undefined) {
-    console.log("Message doesn't contain text, returned. (msg.content === undefined)")
-    return
-  }
-
-  if (msg.channel instanceof DiscordBot.DMChannel) {
-    console.log(
-      "Message was sent in a private chat, returned. (msg.channel instanceof DiscordBot.DMChannel)"
-    )
-    msg.reply("Sorry, I work only in servers.")
-    return
-  }
-
-  const exceptMatch = msg.content.match(/\/except (.+)/)
-  const removeMatch = msg.content.match(/\/remove (.+)/)
-
-  if (exceptMatch) {
-    handleExcept(msg, exceptMatch)
-  } else if (removeMatch) {
-    handleRemove(msg, removeMatch)
-  }
-
-  const translationContext = await core.translateAndCheck(msg.content)
-
-  if (!translationContext) {
-    console.log("translationContext is null. That's probably an error. Returned.")
-    return
-  }
-
-  if (!translationContext.isCorrectLang) {
-    const permitted = await core.shouldBePermitted(msg.content)
-
-    if (!permitted && translationContext.translation) {
-      performAction(
-        msg,
-        translationContext.translation.detectedLangName,
-        translationContext.requiredLangName,
-        translationContext.translation.translatedText
-      )
-    }
-  }
-})
-
-/**
- * Performs an action on the user (whether to just remind him to use the
- * specified language, or ban him).
- */
-async function performAction(
-  msg: DiscordBot.Message,
-  detectedLangName: string,
-  requiredLangName: string,
-  translatedText: string
-): Promise<void> {
-  if (!msg.member) {
-    console.log("msg.member is undefined. Returned.")
-    return
-  }
-
-  console.log(`Performing rebuke/mute/translate action on user ${msg.author.username}...`)
-  let message = `Hey, man, don't speak this ${detectedLangName} anymore! We only do ${requiredLangName} down here.\n`
-
-  if (config.MUTE_PEOPLE && !isAdminUser(msg.member)) {
-    mute(msg)
-    message += `You've been muted for ${config.MUTE_TIMEOUT / 1000} seconds.\n`
-  }
-
-  if (config.BE_HELPFUL) {
-    if (translatedText !== msg.content) {
-      message += `BTW, they tried to say "${translatedText}"`
-    } else {
-      message += "BTW, I've no idea what they tried to say."
-    }
-  }
-
-  msg.reply(message)
-}
-
-/**
- * Temporarily mutes the user for sending the inappropriate messages.
- * Mutes only if the user is not an admin.
- * @param {DiscordBot.Message} msg Discord Message object
- */
-async function mute(msg: DiscordBot.Message): Promise<void> {
-  console.log(`mute() function invoked for user ${msg.author.username}`)
-
-  if (!msg.guild) {
-    console.error(
-      "Something very weird has happened. Somehow, there doesn't appear to be a Discord server"
-    )
-    return
-  }
-
-  msg.guild.channels.cache.forEach(async channel => {
+  /**
+   * Performs an action on the user (whether to just remind him to use the
+   * specified language, or ban him).
+   */
+  async performAction(
+    msg: DiscordBot.Message,
+    detectedLangName: string,
+    requiredLangName: string,
+    translatedText: string
+  ): Promise<void> {
     if (!msg.member) {
-      console.log("Message author is no longer a server member. Returned")
+      console.log("msg.member is undefined. Returned.")
       return
     }
 
-    await channel.overwritePermissions(
-      [
-        {
-          id: msg.member,
-          deny: "SEND_MESSAGES"
-        }
-      ],
-      "Spoke wrong language"
-    )
-  })
+    console.log(`Performing rebuke/mute/translate action on user ${msg.author.username}...`)
+    let message = `Hey, man, don't speak this ${detectedLangName} anymore! We only do ${requiredLangName} down here.\n`
 
-  console.log(`Muting user ${msg.author.username} for ${config.MUTE_TIMEOUT / 1000} seconds.`)
+    if (config.MUTE_PEOPLE && !EnforcingDiscordBot.isAdminUser(msg.member)) {
+      this.mute(msg)
+      message += `You've been muted for ${config.MUTE_TIMEOUT / 1000} seconds.\n`
+    }
 
-  setTimeout(async () => {
+    if (config.BE_HELPFUL) {
+      if (translatedText !== msg.content) {
+        message += `BTW, they tried to say "${translatedText}"`
+      } else {
+        message += "BTW, I've no idea what they tried to say."
+      }
+    }
+
+    msg.reply(message)
+  }
+
+  /**
+   * Temporarily mutes the user for sending the inappropriate messages.
+   * Mutes only if the user is not an admin.
+   * @param {DiscordBot.Message} msg Discord Message object
+   */
+  async mute(msg: DiscordBot.Message): Promise<void> {
+    console.log(`mute() function invoked for user ${msg.author.username}`)
+
     if (!msg.guild) {
       console.error(
         "Something very weird has happened. Somehow, there doesn't appear to be a Discord server"
@@ -198,12 +131,82 @@ async function mute(msg: DiscordBot.Message): Promise<void> {
         [
           {
             id: msg.member,
-            allow: "SEND_MESSAGES"
+            deny: "SEND_MESSAGES"
           }
         ],
-        "Spoke wrong language - Timeout over"
+        "Spoke wrong language"
       )
     })
-    console.log(`Unmuted user ${msg.author.username}.`)
-  }, config.MUTE_TIMEOUT)
+
+    console.log(`Muting user ${msg.author.username} for ${config.MUTE_TIMEOUT / 1000} seconds.`)
+
+    setTimeout(async () => {
+      if (!msg.guild) {
+        console.error(
+          "Something very weird has happened. Somehow, there doesn't appear to be a Discord server"
+        )
+        return
+      }
+
+      msg.guild.channels.cache.forEach(async channel => {
+        if (!msg.member) {
+          console.log("Message author is no longer a server member. Returned")
+          return
+        }
+
+        await channel.overwritePermissions(
+          [
+            {
+              id: msg.member,
+              allow: "SEND_MESSAGES"
+            }
+          ],
+          "Spoke wrong language - Timeout over"
+        )
+      })
+      console.log(`Unmuted user ${msg.author.username}.`)
+    }, config.MUTE_TIMEOUT)
+  }
+
+  /**
+   * Handles adding words to the exception list
+   */
+  async handleExcept(msg: DiscordBot.Message, match): Promise<void> {
+    if (!msg.member || !EnforcingDiscordBot.isAdminUser(msg.member)) {
+      console.log("User is not an admin or has left the server. Returned.")
+      msg.reply("Sorry, this is a admin-only feature.")
+      return
+    }
+
+    const inputText = match[1]
+
+    const successful = await core.addException(inputText)
+
+    if (successful) {
+      msg.reply(`Okay, "${inputText}" has been added to the exception list. `)
+    } else {
+      msg.reply(`An error occurred while adding the word ${inputText}`)
+    }
+  }
+
+  /**
+   * Handles removing words from the exception list
+   */
+  async handleRemove(msg: DiscordBot.Message, match): Promise<void> {
+    if (!msg.member || !EnforcingDiscordBot.isAdminUser(msg.member)) {
+      console.log("User is not an admin or has left the server. Returned.")
+      msg.reply("Sorry, this is a admin-only feature.")
+      return
+    }
+
+    const inputText = match[1]
+
+    const successful = await core.removeException(inputText)
+
+    if (successful) {
+      msg.reply(`Okay, "${inputText}" has been removed from the exception list. `)
+    } else {
+      msg.reply(`An error occurred while removing the word ${inputText}`)
+    }
+  }
 }

--- a/src/discord/types_discord.ts
+++ b/src/discord/types_discord.ts
@@ -2,14 +2,14 @@
  * Discord-specific configuration.
  */
 export class DiscordConfig {
-  TOKEN: string
+  DISCORD_TOKEN: string
 
   constructor() {
     if (!process.env.DISCORD_TOKEN) throw new Error("DISCORD_TOKEN is missing!")
 
     const TOKEN = process.env.DISCORD_TOKEN
 
-    this.TOKEN = TOKEN
+    this.DISCORD_TOKEN = TOKEN
 
     // console.log(`Created DiscordConfig object. TOKEN: ${TOKEN}`)
   }

--- a/src/telegram/bot_telegram.ts
+++ b/src/telegram/bot_telegram.ts
@@ -10,7 +10,7 @@ const { config } = core
 
 export class EnforcingTelegramBot extends TelegramBot {
   constructor(telegramConfig: TelegramConfig) {
-    super(telegramConfig.TOKEN, { polling: true })
+    super(telegramConfig.TELEGRAM_TOKEN, { polling: true })
 
     // The essence of this bot, scan all messages
     this.on("message", async msg => {

--- a/src/telegram/bot_telegram.ts
+++ b/src/telegram/bot_telegram.ts
@@ -7,195 +7,206 @@ import * as core from "../core/core"
 import { TelegramConfig } from "./types_telegram"
 
 const { config } = core
-const telegramConfig = new TelegramConfig()
 
-export const bot = new TelegramBot(telegramConfig.TOKEN, { polling: true })
+export class EnforcingTelegramBot extends TelegramBot {
+  constructor(telegramConfig: TelegramConfig) {
+    super(telegramConfig.TOKEN, { polling: true })
 
-/**
- * Returns true if the user is an admin or a creator, false otherwise.
- */
-function isAdminUser(chatMember: TelegramBot.ChatMember): boolean {
-  return chatMember.status === "administrator" || chatMember.status === "creator"
-}
+    // The essence of this bot, scan all messages
+    this.on("message", async msg => {
+      if (msg.text === undefined) {
+        console.log("Message doesn't contain text, returned. (msg.text === undefined)")
+        return
+      }
 
-// Handles adding messages from the database
-bot.onText(/\/except (.+)/, async (msg, match) => {
-  const chatId = msg.chat.id
-  const userId = msg.from?.id
+      if (msg.chat.type === "private") {
+        console.log("Message was sent in a private chat, returned. (msg.chat.type === private)")
+        await this.sendMessage(msg.chat.id, "Sorry, I work only in groups.")
+        return
+      }
 
-  if (!match) {
-    console.log("match is undefined. Returned.")
-    return
-  }
+      const translationContext = await core.translateAndCheck(msg.text)
 
-  if (!userId) {
-    console.log("userId is undefined. Returned.")
-    return
-  }
+      if (!translationContext) {
+        console.log("translationData is null. That's probably an error. Returned.")
+        return
+      }
 
-  const chatMember = await bot.getChatMember(chatId, userId.toString())
+      if (!translationContext.isCorrectLang) {
+        const permitted = await core.shouldBePermitted(msg.text)
 
-  if (!isAdminUser(chatMember)) {
-    console.log("User is not an admin. Returned.")
-    await bot.sendMessage(chatId, `Sorry, this is a admin-only feature.`)
-    return
-  }
-
-  // "match" is the result of executing the regexp above on the message's text
-  const inputText = match[1].toLowerCase()
-  if (!inputText) {
-    console.log("inputText is undefined. Returned.")
-  }
-
-  const successful = await core.addException(inputText)
-
-  if (successful) {
-    await bot.sendMessage(chatId, `Okay, "${inputText}" has been added to the exception list. `)
-  } else {
-    await bot.sendMessage(chatId, `An error occurred while adding the word ${inputText}`)
-  }
-})
-
-// Handles removing messages from the database
-bot.onText(/\/remove (.+)/, async (msg, match) => {
-  const chatId = msg.chat.id
-  const userId = msg.from?.id
-
-  if (!match) {
-    console.log("match is undefined. Returned.")
-    return
-  }
-
-  if (!userId) {
-    console.log("userId is undefined. Returned.")
-    return
-  }
-
-  const chatMember = await bot.getChatMember(chatId, userId.toString())
-
-  if (!isAdminUser(chatMember)) {
-    console.log("User is not an admin. Returned.")
-    await bot.sendMessage(chatId, `Sorry, this is a admin-only feature.`)
-    return
-  }
-
-  const inputText = match[1].toLowerCase()
-  if (!inputText) {
-    console.log("inputText is undefined. Returned.")
-  }
-
-  const successful = await core.removeException(inputText)
-
-  // send back the matched "whatever" to the chat
-  if (successful) {
-    await bot.sendMessage(chatId, `Okay, "${inputText}" has been removed from the exception list.`)
-  } else {
-    await bot.sendMessage(chatId, `An error occurred while removing the word ${inputText}`)
-  }
-})
-
-// Handles all messages and checks whether they're in the specified language
-bot.on("message", async msg => {
-  if (msg.text === undefined) {
-    console.log("Message doesn't contain text, returned. (msg.text === undefined)")
-    return
-  }
-
-  if (msg.chat.type === "private") {
-    console.log("Message was sent in a private chat, returned. (msg.chat.type === private)")
-    await bot.sendMessage(msg.chat.id, "Sorry, I work only in groups.")
-    return
-  }
-
-  const translationContext = await core.translateAndCheck(msg.text)
-
-  if (!translationContext) {
-    console.log("translationData is null. That's probably an error. Returned.")
-    return
-  }
-
-  if (!translationContext.isCorrectLang) {
-    const permitted = await core.shouldBePermitted(msg.text)
-
-    if (!permitted && translationContext.translation) {
-      await performAction(
-        msg,
-        translationContext.translation.detectedLangName,
-        translationContext.requiredLangName,
-        translationContext.translation.translatedText
-      )
-    }
-  }
-})
-
-/**
- * Performs an action on the user. An action is e.g rebuking the user or muting him
- * for some time.
- */
-async function performAction(
-  msg: TelegramBot.Message,
-  detectedLangName: string,
-  requiredLangName: string,
-  translatedText: string
-): Promise<void> {
-  if (!msg.from) {
-    console.log("msg.from is undefined. Returned.")
-    return
-  }
-
-  console.log(`Performing rebuke/mute/translate action on user ${msg.from.first_name}.`)
-  let message = `Hey, man, don't speak this ${detectedLangName} anymore! We only do ${requiredLangName} down here.\n`
-
-  const sender = await bot.getChatMember(msg.chat.id, msg.from.id.toString())
-
-  if (config.MUTE_PEOPLE && !isAdminUser(sender)) {
-    await mute(msg, sender)
-    message += `You've been muted for ${config.MUTE_TIMEOUT / 1000} seconds.\n`
-  }
-
-  if (config.BE_HELPFUL) {
-    if (translatedText !== msg.text) {
-      message += `BTW, they tried to say "${translatedText}"`
-    } else {
-      message += "BTW, I've no idea what they tried to say."
-    }
-  }
-
-  await bot.sendMessage(msg.chat.id, message, {
-    reply_to_message_id: msg.message_id,
-    parse_mode: "HTML"
-  })
-}
-
-/**
- * Temporarily mutes the user for sending the inappropriate messages.
- * Mutes only if the user is not an admin.
- * @param {TelegramBot.Message} msg Telegram Message object
- */
-async function mute(msg: TelegramBot.Message, sender: TelegramBot.ChatMember): Promise<void> {
-  const isAdmin = isAdminUser(sender)
-
-  console.log(`mute() function invoked for user ${sender.user.first_name}, isAdmin: ${isAdmin}`)
-
-  if (!isAdmin) {
-    await bot.restrictChatMember(msg.chat.id, sender.user.id.toString(), {
-      can_send_messages: false,
-      can_send_media_messages: false,
-      can_send_other_messages: false,
-      can_add_web_page_previews: false
+        if (!permitted && translationContext.translation) {
+          await this.performAction(
+            msg,
+            translationContext.translation.detectedLangName,
+            translationContext.requiredLangName,
+            translationContext.translation.translatedText
+          )
+        }
+      }
     })
 
-    console.log(`Muting user ${sender.user.first_name} for ${config.MUTE_TIMEOUT / 1000} seconds.`)
+    // Handles adding messages from the database
+    this.onText(/\/except (.+)/, async (msg, match) => {
+      const chatId = msg.chat.id
+      const userId = msg.from?.id
 
-    setTimeout(async () => {
-      await bot.restrictChatMember(msg.chat.id, sender.user.id.toString(), {
-        can_send_messages: true,
-        can_send_media_messages: true,
-        can_send_other_messages: true,
-        can_add_web_page_previews: true
+      if (!match) {
+        console.log("match is undefined. Returned.")
+        return
+      }
+
+      if (!userId) {
+        console.log("userId is undefined. Returned.")
+        return
+      }
+
+      const chatMember = await this.getChatMember(chatId, userId.toString())
+
+      if (!EnforcingTelegramBot.isAdminUser(chatMember)) {
+        console.log("User is not an admin. Returned.")
+        await this.sendMessage(chatId, `Sorry, this is a admin-only feature.`)
+        return
+      }
+
+      // "match" is the result of executing the regexp above on the message's text
+      const inputText = match[1].toLowerCase()
+      if (!inputText) {
+        console.log("inputText is undefined. Returned.")
+      }
+
+      const successful = await core.addException(inputText)
+
+      if (successful) {
+        await this.sendMessage(
+          chatId,
+          `Okay, "${inputText}" has been added to the exception list. `
+        )
+      } else {
+        await this.sendMessage(chatId, `An error occurred while adding the word ${inputText}`)
+      }
+    })
+
+    // Handles removing messages from the database
+    this.onText(/\/remove (.+)/, async (msg, match) => {
+      const chatId = msg.chat.id
+      const userId = msg.from?.id
+
+      if (!match) {
+        console.log("match is undefined. Returned.")
+        return
+      }
+
+      if (!userId) {
+        console.log("userId is undefined. Returned.")
+        return
+      }
+
+      const chatMember = await this.getChatMember(chatId, userId.toString())
+
+      if (!EnforcingTelegramBot.isAdminUser(chatMember)) {
+        console.log("User is not an admin. Returned.")
+        await this.sendMessage(chatId, `Sorry, this is a admin-only feature.`)
+        return
+      }
+
+      const inputText = match[1].toLowerCase()
+      if (!inputText) {
+        console.log("inputText is undefined. Returned.")
+      }
+
+      const successful = await core.removeException(inputText)
+
+      // send back the matched "whatever" to the chat
+      if (successful) {
+        await this.sendMessage(
+          chatId,
+          `Okay, "${inputText}" has been removed from the exception list.`
+        )
+      } else {
+        await this.sendMessage(chatId, `An error occurred while removing the word ${inputText}`)
+      }
+    })
+  }
+
+  /**
+   * @returns true if the user is an admin or a creator, false otherwise.
+   */
+  static isAdminUser(chatMember: TelegramBot.ChatMember): boolean {
+    return chatMember.status === "administrator" || chatMember.status === "creator"
+  }
+
+  /**
+   * Performs an action on the user. An action is e.g rebuking the user or muting him
+   * for some time.
+   */
+  async performAction(
+    msg: TelegramBot.Message,
+    detectedLangName: string,
+    requiredLangName: string,
+    translatedText: string
+  ): Promise<void> {
+    if (!msg.from) {
+      console.log("msg.from is undefined. Returned.")
+      return
+    }
+
+    console.log(`Performing rebuke/mute/translate action on user ${msg.from.first_name}.`)
+    let message = `Hey, man, don't speak this ${detectedLangName} anymore! We only do ${requiredLangName} down here.\n`
+
+    const sender = await this.getChatMember(msg.chat.id, msg.from.id.toString())
+
+    if (config.MUTE_PEOPLE && !EnforcingTelegramBot.isAdminUser(sender)) {
+      await this.mute(msg, sender)
+      message += `You've been muted for ${config.MUTE_TIMEOUT / 1000} seconds.\n`
+    }
+
+    if (config.BE_HELPFUL) {
+      if (translatedText !== msg.text) {
+        message += `BTW, they tried to say "${translatedText}"`
+      } else {
+        message += "BTW, I've no idea what they tried to say."
+      }
+    }
+
+    await this.sendMessage(msg.chat.id, message, {
+      reply_to_message_id: msg.message_id,
+      parse_mode: "HTML"
+    })
+  }
+
+  /**
+   * Temporarily mutes the user for sending the inappropriate messages.
+   * Mutes only if the user is not an admin.
+   * @param {TelegramBot.Message} msg Telegram Message object
+   */
+  async mute(msg: TelegramBot.Message, sender: TelegramBot.ChatMember): Promise<void> {
+    const isAdmin = EnforcingTelegramBot.isAdminUser(sender)
+
+    console.log(`mute() function invoked for user ${sender.user.first_name}, isAdmin: ${isAdmin}`)
+
+    if (!isAdmin) {
+      await this.restrictChatMember(msg.chat.id, sender.user.id.toString(), {
+        can_send_messages: false,
+        can_send_media_messages: false,
+        can_send_other_messages: false,
+        can_add_web_page_previews: false
       })
 
-      console.log(`Unmuted user ${sender.user.first_name}.`)
-    }, config.MUTE_TIMEOUT)
+      console.log(
+        `Muting user ${sender.user.first_name} for ${config.MUTE_TIMEOUT / 1000} seconds.`
+      )
+
+      setTimeout(async () => {
+        await this.restrictChatMember(msg.chat.id, sender.user.id.toString(), {
+          can_send_messages: true,
+          can_send_media_messages: true,
+          can_send_other_messages: true,
+          can_add_web_page_previews: true
+        })
+
+        console.log(`Unmuted user ${sender.user.first_name}.`)
+      }, config.MUTE_TIMEOUT)
+    }
   }
 }

--- a/src/telegram/types_telegram.ts
+++ b/src/telegram/types_telegram.ts
@@ -2,14 +2,14 @@
  * Telegram-specific configuration.
  */
 export class TelegramConfig {
-  TOKEN: string
+  TELEGRAM_TOKEN: string
 
   constructor() {
     if (!process.env.TELEGRAM_TOKEN) throw new Error("TELEGRAM_TOKEN is missing!")
 
     const TOKEN = process.env.TELEGRAM_TOKEN
 
-    this.TOKEN = TOKEN
+    this.TELEGRAM_TOKEN = TOKEN
 
     // console.log(`Created TelegramConfig object. TOKEN: ${TOKEN}`)
   }


### PR DESCRIPTION
## What happened
I rewrote `bot_telegram.ts` and `bot_discord.ts` to be object-oriented (or at least I tried).
- Created `EnforcingTelegramBot` extending `TelegramBot` 
- Created `EnforcingDiscordBot` extending `DiscordBot.Client`
- Instances of `EnforcingTelegramBot` and `EnforcingDiscordBot` are created in `app.ts` basing on [command line arguments](https://stackoverflow.com/questions/4351521/how-do-i-pass-command-line-arguments-to-a-node-js-program) passed.

#### Example:
`node lib/app.js --telegram` runs only Telegram bot.

`node lib/app.js --telegram --discord` runs both Telegram and Discord bots.

Of course, you won't care about the above, because it's wrapped nicely by `npm run telegram`, `npm run discord` and `npm start` (which runs both)

This way it's more modular and the particular components are less coupled. 

**PS** This PR is against `dev` branch, I'd like this to be a typical workflow so we can safely develop new features but always have a well-tested and working `master`.

> It's 4:21 AM, let's call it a day
